### PR TITLE
Check if ENT is valid before checking line

### DIFF
--- a/gamemode/maps/slash_subway.lua
+++ b/gamemode/maps/slash_subway.lua
@@ -114,7 +114,7 @@ if CLIENT then
 		local curtime = CurTime()
 		local ply = LocalPlayer()
 
-		if !ply:Alive() or !ply:IsLineOfSightClear( v )  or !v:IsValid() or v == ply then return end
+		if !ply:Alive() or !v:IsValid() or !ply:IsLineOfSightClear( v ) or v == ply then return end
 
 
 		local TargetPosMax= v:GetPos()+ v:OBBMaxs() - Vector(10,0,0)


### PR DESCRIPTION
**Without this small correction we can have this error :**
```
[Slashers Gamemode] gamemodes/slashers/gamemode/maps/slash_subway.lua:117: bad argument #1 to 'IsLineOfSightClear' (Vector expected, got nil)
  1. IsLineOfSightClear - [C]:-1
   2. fn - gamemodes/slashers/gamemode/maps/slash_subway.lua:117
    3. unknown - addons/ulib_557962238/lua/ulib/shared/hook.lua:109
```